### PR TITLE
Startup info parsing and typos fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,34 +139,29 @@ Quit interactive mode
 ```
 #!/usr/bin/env python3
 
-import os
-import sys
-import pprint
-import datetime
-
-from google.protobuf.json_format import MessageToDict
+from flipperzero_protobuf.cli_helpers import print_hex, dict2datetime
 from flipperzero_protobuf.flipper_proto import FlipperProto
-from flipperzero_protobuf.cli_helpers import *
+
 
 def main():
 
     proto = FlipperProto()
 
     print("\n\nPing")
-    ping_rep = proto.rcp_system_ping()
+    ping_rep = proto.rpc_system_ping()
     print_hex(ping_rep)
 
     print("\n\n]DeviceInfo")
-    ping_rep = proto.rcp_device_info()
-    print(ping_rep)
+    device_info = proto.rpc_device_info()
+    print(device_info)
 
     print("\n\nGetDateTime")
-    dtime_resp = proto.rcp_get_datetime()
+    dtime_resp = proto.rpc_get_datetime()
     dt = dict2datetime(dtime_resp)
     print(dt.ctime())
 
     print("\n\nList files")
-    list_resp = proto.rcp_storage_list('/ext')
+    list_resp = proto.rpc_storage_list('/ext')
     for li in list_resp:
         print(f"[{li['type']}]\t{li['name']}")
 
@@ -174,8 +169,10 @@ def main():
     print("\n\nrun Infrared App")
     proto.rpc_app_start('Infrared', '/ext/infrared/Tv_Tivo.ir')
 
+
 if __name__ == '__main__':
     main()
+
 ```
 
 ---

--- a/flipperzero_protobuf/flipper_base.py
+++ b/flipperzero_protobuf/flipper_base.py
@@ -75,7 +75,7 @@ class FlipperProtoBase:
         return self._serial.port
 
     def _get_startup_info(self) -> dict:
-        """read / record info during startip"""
+        """read / record info during startup"""
         # cache some data
         ret = {}
         self._serial.read_until(b">: ")
@@ -89,7 +89,7 @@ class FlipperProtoBase:
                 break
 
             if len(r) > 5:
-                k, v = r.split(":")
+                k, v = r.split(":", maxsplit=1)
                 ret[k.strip()] = v.strip()
 
         return ret


### PR DESCRIPTION
When there was an URL with colon in `firmware_origin_git` contents (like for example in git remote URL), method `_get_startup_info` failed to parse it.

Also fixed an example of API usage in readme - typo in methods; the example did not work.